### PR TITLE
Clean code from second week

### DIFF
--- a/theories/Deduction.v
+++ b/theories/Deduction.v
@@ -66,8 +66,8 @@ Proof.
       (* RImp *)  ? ? ? _ IHind | ? ? ? _ IHind1 _ IHind2 |
       (* RConj *) ? ? ? _ IHind1 _ IHind2 | ? ? ? _ IHind | ? ? ? _ IHind |
       (* RDisj *) ? ? ? _ IHind | ? ? ? _ IHind | ? ? ? ? _ IHind1 _ IHind2 _ IHind3 |
-      (* RForAll *) ? ? _ IHind | ? ? t _ IHind |
-      (* RExists *) ? ? t _ IHind | ? ? ? _ IHind1 _ IHind2 ];
+      (* RForAll *) ? ? _ IHind | ? ? phi _ IHind |
+      (* RExists *) ? ? phi _ IHind | ? ? ? _ IHind1 _ IHind2 ];
     simpl in *; intros sigma IHtree; intros.
 
   (* RAxiom *)
@@ -76,7 +76,7 @@ Proof.
   (* RTop_i *)
   - exact I.
 
-  (* RTop_e *)
+  (* RBot_e *)
   - exfalso.
     apply (IHind sigma).
     apply IHtree.
@@ -132,15 +132,13 @@ Proof.
     apply IHtree.
 
   (* RForAll_e *)
-  - replace t with (term_lift 0 0 t).
-    2: { apply term_lift_0. }
-
+  - rewrite <- (term_lift_0 phi 0).
     apply formula_eval_subst_lift with (sigma := nil).
     apply IHind.
     apply IHtree.
 
   (* RExists_i *)
-  - exists (term_eval fcts sigma t).
+  - exists (term_eval fcts sigma phi).
     apply formula_eval_subst_lift with (sigma := nil).
     rewrite term_lift_0.
     apply IHind.
@@ -157,6 +155,7 @@ Proof.
     apply IHtree.
 Qed.
 
+
 Lemma derivable_weak' (gamma: list formula) (phi: formula):
   Derivable gamma phi ->
     forall (gamma' gamma'': list formula) (phi': formula),
@@ -168,7 +167,7 @@ Proof.
       (* RConj *) ? ? ? _ IHind1 _ IHind2 | ? A B _ IHind | ? A B _ IHind |
       (* RDisj *) ? ? ? _ IHind | ? ? ? _ IHind | ? A B C _ IHind1 _ IHind2 _ IHind3 |
       (* RForAll *) ? ? _ IHind | ? ? ? _ IHind |
-      (* RExists *) ? ? t _ IHind | ? t ? _ IHind1 _ IHind2 ];
+      (* RExists *) ? ? phi _ IHind | ? phi ? _ IHind1 _ IHind2 ];
     simpl in *; intros gamma' gamma'' phi'' ->.
 
   (* RAxiom *)
@@ -194,7 +193,7 @@ Proof.
   (* RTop_i *)
   - apply RTop_i.
 
-  (* RTop_e *)
+  (* RBot_e *)
   - apply RBot_e.
     apply IHind.
     reflexivity.
@@ -263,12 +262,12 @@ Proof.
     reflexivity.
 
   (* RExists_i *)
-  - apply RExists_i with t.
+  - apply RExists_i with phi.
     apply IHind.
     reflexivity.
 
   (* RExists_e *)
-  - apply RExists_e with t.
+  - apply RExists_e with phi.
     + apply IHind1.
       reflexivity.
     + rewrite <- context_lift_app; simpl.
@@ -301,4 +300,231 @@ Lemma derivable_weak_phi (gamma: list formula) (phi phi': formula):
   Derivable gamma phi -> Derivable (phi' :: gamma) phi.
 Proof.
   apply (derivable_weak nil).
+Defined.
+
+
+Lemma derivable_lift (gamma: list formula) (phi: formula):
+  Derivable gamma phi ->
+    forall (idx: nat), Derivable (context_lift idx 1 gamma) (formula_lift idx 1 phi).
+Proof.
+  induction 1 as
+    [ | | ? ? _ IHind |
+      (* RImp *)  ? ? ? _ IHind | ? A B _ IHind1 _ IHind2 |
+      (* RConj *) ? ? ? _ IHind1 _ IHind2 | ? A B _ IHind | ? A B _ IHind |
+      (* RDisj *) ? ? ? _ IHind | ? ? ? _ IHind | ? A B C _ IHind1 _ IHind2 _ IHind3 |
+      (* RForAll *) ? ? _ IHind | ? ? ? _ IHind |
+      (* RExists *) ? ? phi _ IHind | ? phi ? _ IHind1 _ IHind2 ];
+    simpl in *; intros idx'.
+
+  (* RAxiom *)
+  - rewrite <- formula_lift_nth.
+    apply RAxiom.
+
+  (* RTop_i *)
+  - apply RTop_i.
+
+  (* RBot_e *)
+  - apply RBot_e.
+    apply IHind.
+
+  (* RImp_i *)
+  - apply RImp_i.
+    apply IHind.
+
+  (* RImp_e *)
+  - apply RImp_e with (formula_lift idx' 1 A).
+    + apply IHind1.
+    + apply IHind2.
+
+  (* RConj_i *)
+  - apply RConj_i.
+    + apply IHind1.
+    + apply IHind2.
+
+  (* RConj_e1 *)
+  - apply RConj_e1 with (formula_lift idx' 1 B).
+    apply IHind.
+
+  (* RConj_e2 *)
+  - apply RConj_e2 with (formula_lift idx' 1 A).
+    apply IHind.
+
+  (* RDisj_i1 *)
+  - apply RDisj_i1.
+    apply IHind.
+
+  (* RDisj_i2 *)
+  - apply RDisj_i2.
+    apply IHind.
+
+  (* RDisj_e *)
+  - apply RDisj_e with (formula_lift idx' 1 A) (formula_lift idx' 1 B).
+    + apply IHind1.
+    + apply IHind2.
+    + apply IHind3.
+
+  (* RForAll_i *)
+  - apply RForAll_i.
+    rewrite <- (PeanoNat.Nat.add_0_l idx').
+    rewrite <- context_lift_S_lift_n; simpl.
+    apply IHind.
+
+  (* RForAll_e *)
+  - rewrite <- (PeanoNat.Nat.add_0_l idx').
+    rewrite <- formula_subst_lift_lift.
+    apply RForAll_e.
+    apply IHind.
+
+  (* RExists_i *)
+  - apply RExists_i with (term_lift idx' 1 phi).
+    rewrite (formula_subst_lift_lift _ 0 idx').
+    apply IHind.
+
+  (* RExists_e *)
+  - apply RExists_e with (formula_lift (S idx') 1 phi).
+    + apply IHind1.
+    + rewrite <- (PeanoNat.Nat.add_0_l idx').
+      rewrite <- context_lift_S_lift_n.
+      rewrite <- formula_lift_S_lift_n; simpl.
+      apply IHind2.
+Defined.
+
+Lemma derivable_subst' (gamma: list formula) (phi: formula):
+  Derivable gamma phi ->
+    forall (phi': formula) (gamma' gamma'': list formula),
+      gamma = gamma' ++ (phi' :: gamma'') ->
+      Derivable gamma'' phi' ->
+      Derivable (gamma' ++ gamma'') phi.
+Proof.
+  induction 1 as
+    [ | | ? ? _ IHind |
+      (* RImp *)  ? ? ? _ IHind | ? A B _ IHind1 _ IHind2 |
+      (* RConj *) ? ? ? _ IHind1 _ IHind2 | ? A B _ IHind | ? A B _ IHind |
+      (* RDisj *) ? ? ? _ IHind | ? ? ? _ IHind | ? A B C _ IHind1 _ IHind2 _ IHind3 |
+      (* RForAll *) ? ? _ IHind | ? ? ? _ IHind |
+      (* RExists *) ? ? phi _ IHind | ? phi ? _ IHind1 _ IHind2 ];
+    simpl in *; intros phi'' gamma' gamma'' -> Hphi''.
+
+  (* RAxiom *)
+  - destruct (PeanoNat.Nat.eqb_spec idx (length gamma')); subst.
+    { rewrite nth_middle.
+      apply derivable_weak_gamma.
+      apply Hphi''. }
+
+    destruct (PeanoNat.Nat.leb_spec0 (S idx) (length gamma')).
+    { rewrite app_nth1; [| lia ].
+      rewrite <- (app_nth1 _ gamma''); [| lia ].
+      apply RAxiom. }
+
+    replace (nth _ _  _) with (nth (idx - 1) (gamma' ++ gamma'') FTop).
+    { apply RAxiom. }
+
+    rewrite !app_nth2; [| lia.. ].
+    replace (_ :: _) with ((phi'' :: nil) ++ gamma''); [| reflexivity ].
+    rewrite !app_nth2; simpl; [| lia ].
+    f_equal.
+    lia.
+
+  (* RTop_i *)
+  - apply RTop_i.
+
+  (* RBot_e *)
+  - apply RBot_e.
+    apply (IHind phi''); [ reflexivity |].
+    apply Hphi''.
+
+  (* RImp_i *)
+  - apply RImp_i.
+    apply (IHind phi'' (phi :: gamma')); simpl; [ reflexivity |].
+    apply Hphi''.
+
+  (* RImp_e *)
+  - apply RImp_e with A.
+    + apply (IHind1 phi''); [ reflexivity |].
+      apply Hphi''.
+
+    + apply (IHind2 phi''); [ reflexivity |].
+      apply Hphi''.
+
+  (* RConj_i *)
+  - apply RConj_i.
+    + apply (IHind1 phi''); [ reflexivity |].
+      apply Hphi''.
+
+    + apply (IHind2 phi''); [ reflexivity |].
+      apply Hphi''.
+
+  (* RConj_e1 *)
+  - apply RConj_e1 with B.
+    apply (IHind phi''); [ reflexivity |].
+    apply Hphi''.
+
+  (* RConj_e2 *)
+  - apply RConj_e2 with A.
+    apply (IHind phi''); [ reflexivity |].
+    apply Hphi''.
+
+  (* RDisj_i1 *)
+  - apply RDisj_i1.
+    apply (IHind phi''); [ reflexivity |].
+    apply Hphi''.
+
+  (* RDisj_i2 *)
+  - apply RDisj_i2.
+    apply (IHind phi''); [ reflexivity |].
+    apply Hphi''.
+
+  (* RDisj_e *)
+  - apply RDisj_e with A B.
+    + apply (IHind1 phi''); [ reflexivity |].
+      apply Hphi''.
+
+    + apply (IHind2 phi'' (A :: gamma')); [ reflexivity |].
+      apply Hphi''.
+
+    + apply (IHind3 phi'' (B :: gamma')); [ reflexivity |].
+      apply Hphi''.
+
+  (* RForAll_i *)
+  - apply RForAll_i.
+    rewrite <- context_lift_app.
+
+    apply (IHind (formula_lift 0 1 phi'')).
+    { rewrite <- context_lift_app; simpl.
+      reflexivity. }
+
+    apply derivable_lift.
+    apply Hphi''.
+
+  (* RForAll_e *)
+  - apply RForAll_e.
+    apply IHind with phi''; [ reflexivity |].
+    apply Hphi''.
+
+  (* RExists_i *)
+  - apply RExists_i with phi.
+    apply IHind with phi''; [ reflexivity |].
+    apply Hphi''.
+
+  (* RExists_e *)
+  - apply RExists_e with phi.
+    { apply IHind1 with phi''; [ reflexivity |].
+      apply Hphi''. }
+
+    rewrite <- context_lift_app.
+    apply (IHind2 (formula_lift 0 1 phi'') (phi :: context_lift 0 1 gamma')); simpl.
+    { rewrite <- context_lift_app; simpl.
+      reflexivity. }
+
+    apply derivable_lift.
+    apply Hphi''.
+Defined.
+
+Lemma derivable_subst (gamma gamma': list formula) (phi phi': formula):
+  Derivable (gamma' ++ phi' :: gamma) phi ->
+    Derivable gamma phi' -> Derivable (gamma' ++ gamma) phi.
+Proof.
+  intros H1 H2.
+  eapply (derivable_subst' _ phi H1 phi'); [ reflexivity |].
+  apply H2.
 Defined.


### PR DESCRIPTION
This PR refactors definitions and proofs, made for the second week.

The names of the lemmas have been changed as follows:
 - `tlift_tsubst` -> `term_subst_lift_S`
 - `ltlift_tsubst` -> `term_subst_lift_S_iter`
 - `lift_subst_comm` -> `formula_subst_lift_lift`
 - `NJ_lift` -> `derivable_lift`
 - `Subst_aux` -> `derivable_subst'`
 - `Subst` -> `derivable_subst`